### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@
 
 ## Star历史
 
-![Star History Chart](https://api.star-history.com/svg?repos=moshstudio/TAICHI-flet&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=moshstudio/TAICHI-flet&type=Date)


### PR DESCRIPTION
The star history chart in the README has stopped rendering because of limits on the stargazer API. This change points the chart to an available alternative backend that does not require an API token, so the chart shows correctly again.